### PR TITLE
Fix transform origin for zoom sync

### DIFF
--- a/script.js
+++ b/script.js
@@ -325,6 +325,7 @@ function handleImage(file) {
       currentImageOriginal.src = img.src;
       imageWrapper.innerHTML = '';
       imageWrapper.appendChild(img);
+      imageWrapper.style.transformOrigin = '0 0';
       currentImage = img;
       
       // CONFIGURACIÓN MEJORADA: Preparar SVG para zoom sincronizado

--- a/styles.css
+++ b/styles.css
@@ -240,6 +240,7 @@ body {
   left: 0;
   width: 100%;
   height: 100%;
+  transform-origin: 0 0;
   transition: transform 0.15s ease-out;
 }
 


### PR DESCRIPTION
## Summary
- set `.image-wrapper` transform origin to the top-left so it matches the SVG overlay
- ensure `handleImage()` also configures the image wrapper with `transformOrigin = '0 0'`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68408b9f3c80832daa2c2983bf6fd926