### PR TITLE
Add server management and selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,6 +139,7 @@ Ver
 <button class="folder-btn" onclick="expandAllFolders()">Expandir Todo</button>
 <button class="folder-btn" onclick="collapseAllFolders()">Contraer Todo</button>
 <button class="folder-btn" onclick="assignCamerasToFolders()">Auto-Asignar</button>
+<button class="folder-btn" onclick="addServer()">Agregar Servidor</button>
 </div>
 
 <div class="search-container">


### PR DESCRIPTION
## Summary
- edit cameras asks for server selection
- add button and function to create new servers
- keep server data when adding pins and exporting CSV

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6843339500b0832d83900e63e7ec370a