### PR TITLE
Modo manual y cámaras sin asignar

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@ Ver
 <div class="folder-controls">
 <button class="folder-btn" onclick="expandAllFolders()">Expandir Todo</button>
 <button class="folder-btn" onclick="collapseAllFolders()">Contraer Todo</button>
-<button class="folder-btn" onclick="assignCamerasToFolders()">Auto-Asignar</button>
+<button class="folder-btn" onclick="assignCamerasToFolders()">Modo Manual</button>
 <button class="folder-btn" onclick="addServer()">Agregar Servidor</button>
 </div>
 

--- a/styles.css
+++ b/styles.css
@@ -677,6 +677,25 @@ display: block;
 }
 
 .notification-title {
-font-weight: bold;
-margin-bottom: 8px;
+  font-weight: bold;
+  margin-bottom: 8px;
+}
+
+.unassigned-folder {
+    font-weight: bold;
+    background-color: #fff3cd;
+    border: 1px solid #ffeaa7;
+}
+
+.unassigned-folder .tree-icon {
+    color: #e17055;
+}
+
+.unassigned-camera {
+    background-color: #fff3cd;
+    font-style: italic;
+}
+
+.unassigned-camera .tree-icon {
+    color: #e17055;
 }


### PR DESCRIPTION
## Summary
- remove automatic distribution in `assignCamerasToFolders`
- keep new cameras unassigned in `addPin`
- respect provided servers when loading CSV files
- display an "Sin Asignar" section in tree view and style it
- support dragging cameras into folders
- update manual assign button text

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_685419f04a68832db63f656282396710